### PR TITLE
updates Micropython example to include timeout

### DIFF
--- a/examples/mpy-example.py
+++ b/examples/mpy-example.py
@@ -54,7 +54,8 @@ def main():
     try:
         if use_uart:
             port = UART(2, 9600)
-            port.init(9600, bits=8, parity=None, stop=1)
+            port.init(9600, bits=8, parity=None, stop=1,
+                      timeout=3000, timeout_char=100)
         else:
             port = I2C()
     except Exception as exception:


### PR DESCRIPTION
Passed lint
mpy-example.py tested on ESP32 running Micropython 1.14