### PR TITLE
feat:deinit i2c for a clean bus

### DIFF
--- a/notecard/notecard.py
+++ b/notecard/notecard.py
@@ -396,6 +396,7 @@ class OpenI2C(Notecard):
         """Reset the Notecard."""
         chunk_len = 0
 
+        self.i2c.deinit()
         while not self.lock():
             pass
 


### PR DESCRIPTION
Adding a `deinit()` before a lock of I2C in note-python to make sure we don't use a bus in a bad state.