### PR TITLE
Updates and fixes for User Agent handling

### DIFF
--- a/notecard/notecard.py
+++ b/notecard/notecard.py
@@ -214,10 +214,8 @@ class Notecard:
         """Inspect the request for hub.set and add the User Agent."""
         if 'hub.set' in req.values():
             # Merge the User Agent to send along with the hub.set request.
-            new_req = req.copy()
-            ua = {'body': self.GetUserAgent()}
-            new_req.update(ua)
-            req = new_req
+            req = req.copy()
+            req.update({'body': self.GetUserAgent()})
 
             self._user_agent_sent = True
         return req

--- a/notecard/notecard.py
+++ b/notecard/notecard.py
@@ -198,6 +198,7 @@ class Notecard:
         'os_platform': sys.platform,
         'os_version': sys.version
     }
+    _user_agent_app = None
     _user_agent_sent = False
 
     def __init__(self):
@@ -214,7 +215,8 @@ class Notecard:
         if 'hub.set' in req.values():
             # Merge the User Agent to send along with the hub.set request.
             new_req = req.copy()
-            new_req.update(self.GetUserAgent())
+            ua = {'body': self.GetUserAgent()}
+            new_req.update(ua)
             req = new_req
 
             self._user_agent_sent = True
@@ -222,7 +224,13 @@ class Notecard:
 
     def GetUserAgent(self):
         """Return the User Agent String for the host for debug purposes."""
-        return self._user_agent
+        ua_copy = self._user_agent.copy()
+        ua_copy.update(self._user_agent_app or {})
+        return ua_copy
+
+    def SetAppUserAgent(self, app_user_agent):
+        """Set the User Agent info for the app."""
+        self._user_agent_app = app_user_agent
 
     def UserAgentSent(self):
         """Return true if the User Agent has been sent to the Notecard."""

--- a/test/test_notecard.py
+++ b/test/test_notecard.py
@@ -414,3 +414,27 @@ class TestNotecardMockI2C(NotecardTest):
         nCard = notecard.OpenI2C(port, 0x17, 255, debug=True)
 
         assert nCard._debug
+
+
+class MockNotecard(notecard.Notecard):
+    def Reset(self):
+        pass
+
+
+class TestUserAgent:
+
+    def setUserAgentInfo(self, info=None):
+        nCard = MockNotecard()
+        orgReq = {"req": "hub.set"}
+        nCard.SetAppUserAgent(info)
+        req = nCard._preprocessReq(orgReq)
+        return req
+
+    def test_amends_hub_set_request(self):
+        req = self.setUserAgentInfo()
+        assert req['body'] is not None
+
+    def test_adds_app_info(self):
+        info = {"app": "myapp"}
+        req = self.setUserAgentInfo(info)
+        assert req['body']['app'] == 'myapp'


### PR DESCRIPTION
## Changes

* added `SetAppUserAgent`, which allows the application to provide a dictionary of app user agent properties. This is merged with the host user agent info. 
* Sends the user agent info as the `body` of the `hub.set` request. 
* Unit tests to verify the expected changes to the `hub.set` request

## Testing

Test Setup:
  * Circuitpython 8.x running on Adafruit nRF52840
  * Notecard + Notecarrier F
  * `notecard` directory from `note-python` library copied to `CIRCUITPY/lib/notecard`
  * Notecard connected to a Notehub project
  
Test Script:

```python
import board
import busio
import notecard

port = busio.I2C(board.SCL, board.SDA)
card = notecard.OpenI2C(port, 0, 0, debug = True)
card.SetAppUserAgent({"app":"myapp"})
req = {"req": "hub.set"}
rsp = card.Transaction(req)
```

Test Output:

```
code.py output:
{"body": {"os_family": "Adafruit Feather nRF52840 Express with nRF52840", "req_interface": "i2c", "os_name": "circuitpython", "os_platform": "nRF52840", "agent": "note-python", "req_port": 0, "os_version": "3.4.0", "app": "myapp"}, "req": "hub.set"}
{}
```

Notehub event:

```json
    "req": "note.update",
    "file": "_env.dbs",
    "note": "_state_vars",
    ...
    "body": {
        ...
        "user_agent": {
            "agent": "note-python",
            "app": "myapp",
            "os_family": "Adafruit Feather nRF52840 Express with nRF52840",
            "os_name": "circuitpython",
            "os_platform": "nRF52840",
            "os_version": "3.4.0",
            "req_interface": "i2c",
            "req_port": 0
        }
    },
    ...
```