### PR TITLE
Extend Notecard I2C transaction timeout to 30 seconds from 10.

### DIFF
--- a/notecard/notecard.py
+++ b/notecard/notecard.py
@@ -355,7 +355,7 @@ class OpenI2C(Notecard):
             chunk_len = 0
             received_newline = False
             start = start_timeout()
-            transaction_timeout_secs = 10
+            transaction_timeout_secs = 30
             while True:
                 time.sleep(.001)
                 reg = bytearray(2)


### PR DESCRIPTION
This change was already made in note-go. We're rolling it out to the other SDKs, now.