### PR TITLE
Implement CTX/RTX.

### DIFF
--- a/notecard/gpio.py
+++ b/notecard/gpio.py
@@ -1,0 +1,239 @@
+"""GPIO abstractions for note-python."""
+
+from .platform import platform
+
+if platform == 'circuitpython':
+    import digitalio
+elif platform == 'micropython':
+    import machine
+elif platform == 'raspbian':
+    import RPi.GPIO as rpi_gpio
+
+
+class GPIO:
+    """GPIO abstraction.
+
+    Supports GPIO on CircuitPython, MicroPython, and Raspbian (Raspberry Pi).
+    """
+
+    IN = 0
+    OUT = 1
+    PULL_UP = 2
+    PULL_DOWN = 3
+    PULL_NONE = 4
+
+    def direction(self, direction):
+        """Set the direction of the pin.
+
+        Does nothing in this base class. Should be implemented by subclasses.
+        """
+        pass
+
+    def pull(self, pull):
+        """Set the pull of the pin.
+
+        Does nothing in this base class. Should be implemented by subclasses.
+        """
+        pass
+
+    def value(self, value=None):
+        """Set the output or get the current level of the pin.
+
+        Does nothing in this base class. Should be implemented by subclasses.
+        """
+        pass
+
+    @staticmethod
+    def setup(pin, direction, pull=None, value=None):
+        """Set up a GPIO.
+
+        The platform is detected internally so that the user doesn't need to
+        write platform-specific code themselves.
+        """
+        if platform == 'circuitpython':
+            return CircuitPythonGPIO(pin, direction, pull, value)
+        elif platform == 'micropython':
+            return MicroPythonGPIO(pin, direction, pull, value)
+        elif platform == 'raspbian':
+            return RpiGPIO(pin, direction, pull, value)
+
+    def __init__(self, pin, direction, pull=None, value=None):
+        """Initialize the GPIO.
+
+        Pin and direction are required arguments. Pull and value will be set
+        only if given.
+        """
+        self.direction(direction)
+
+        if pull is not None:
+            self.pull(pull)
+
+        if value is not None:
+            self.value(value)
+
+
+class CircuitPythonGPIO(GPIO):
+    """GPIO for CircuitPython."""
+
+    def direction(self, direction):
+        """Set the direction of the pin.
+
+        Allowed direction values are GPIO.IN and GPIO.OUT. Other values cause a
+        ValueError.
+        """
+        if direction == GPIO.IN:
+            self.pin.direction = digitalio.Direction.INPUT
+        elif direction == GPIO.OUT:
+            self.pin.direction = digitalio.Direction.OUTPUT
+        else:
+            raise ValueError(f"Invalid pin direction: {direction}.")
+
+    def pull(self, pull):
+        """Set the pull of the pin.
+
+        Allowed pull values are GPIO.PULL_UP, GPIO.PULL_DOWN, and
+        GPIO.PULL_NONE. Other values cause a ValueError.
+        """
+        if pull == GPIO.PULL_UP:
+            self.pin.pull = digitalio.Pull.UP
+        elif pull == GPIO.PULL_DOWN:
+            self.pin.pull = digitalio.Pull.DOWN
+        elif pull == GPIO.PULL_NONE:
+            self.pin.pull = None
+        else:
+            raise ValueError(f"Invalid pull value: {pull}.")
+
+    def value(self, value=None):
+        """Set the output or get the current level of the pin.
+
+        If value is not given, returns the level of the pin (i.e. the pin is an
+        input). If value is given, sets the level of the pin (i.e. the pin is an
+        output).
+        """
+        if value is None:
+            return self.pin.value
+        else:
+            self.pin.value = value
+
+    def __init__(self, pin, direction, pull=None, value=None):
+        """Initialize the GPIO.
+
+        Pin and direction are required arguments. Pull and value will be set
+        only if given.
+        """
+        self.pin = digitalio.DigitalInOut(pin)
+        super().__init__(pin, direction, pull, value)
+
+
+class MicroPythonGPIO(GPIO):
+    """GPIO for MicroPython."""
+
+    def direction(self, direction):
+        """Set the direction of the pin.
+
+        Allowed direction values are GPIO.IN and GPIO.OUT. Other values cause a
+        ValueError.
+        """
+        if direction == GPIO.IN:
+            self.pin.init(mode=machine.Pin.IN)
+        elif direction == GPIO.OUT:
+            self.pin.init(mode=machine.Pin.OUT)
+        else:
+            raise ValueError(f"Invalid pin direction: {direction}.")
+
+    def pull(self, pull):
+        """Set the pull of the pin.
+
+        Allowed pull values are GPIO.PULL_UP, GPIO.PULL_DOWN, and
+        GPIO.PULL_NONE. Other values cause a ValueError.
+        """
+        if pull == GPIO.PULL_UP:
+            self.pin.init(pull=machine.Pin.PULL_UP)
+        elif pull == GPIO.PULL_DOWN:
+            self.pin.init(pull=machine.Pin.PULL_DOWN)
+        elif pull == GPIO.PULL_NONE:
+            self.pin.init(pull=None)
+        else:
+            raise ValueError(f"Invalid pull value: {pull}.")
+
+    def value(self, value=None):
+        """Set the output or get the current level of the pin.
+
+        If value is not given, returns the level of the pin (i.e. the pin is an
+        input). If value is given, sets the level of the pin (i.e. the pin is an
+        output).
+        """
+        if value is None:
+            return self.pin.value()
+        else:
+            self.pin.init(value=value)
+
+    def __init__(self, pin, direction, pull=None, value=None):
+        """Initialize the GPIO.
+
+        Pin and direction are required arguments. Pull and value will be set
+        only if given.
+        """
+        self.pin = machine.Pin(pin)
+        super().__init__(pin, direction, pull, value)
+
+
+class RpiGPIO(GPIO):
+    """GPIO for Raspbian (Raspberry Pi)."""
+
+    def direction(self, direction):
+        """Set the direction of the pin.
+
+        Allowed direction values are GPIO.IN and GPIO.OUT. Other values cause a
+        ValueError.
+        """
+        if direction == GPIO.IN:
+            self.rpi_direction = rpi_gpio.IN
+            rpi_gpio.setup(self.pin, direction=rpi_gpio.IN)
+        elif direction == GPIO.OUT:
+            self.rpi_direction = rpi_gpio.OUT
+            rpi_gpio.setup(self.pin, direction=rpi_gpio.OUT)
+        else:
+            raise ValueError(f"Invalid pin direction: {direction}.")
+
+    def pull(self, pull):
+        """Set the pull of the pin.
+
+        Allowed pull values are GPIO.PULL_UP, GPIO.PULL_DOWN, and
+        GPIO.PULL_NONE. Other values cause a ValueError.
+        """
+        if pull == GPIO.PULL_UP:
+            rpi_gpio.setup(self.pin,
+                           direction=self.rpi_direction,
+                           pull_up_down=rpi_gpio.PUD_UP)
+        elif pull == GPIO.PULL_DOWN:
+            rpi_gpio.setup(self.pin,
+                           direction=self.rpi_direction,
+                           pull_up_down=GPIO.PUD_DOWN)
+        elif pull == GPIO.PULL_NONE:
+            rpi_gpio.setup(self.pin,
+                           direction=self.rpi_direction,
+                           pull_up_down=rpi_gpio.PUD_OFF)
+        else:
+            raise ValueError(f"Invalid pull value: {pull}.")
+
+    def value(self, value=None):
+        """Set the output or get the current level of the pin.
+
+        If value is not given, returns the level of the pin (i.e. the pin is an
+        input). If value is given, sets the level of the pin (i.e. the pin is an
+        output).
+        """
+        if value is None:
+            return rpi_gpio.input(self.pin)
+        else:
+            rpi_gpio.output(self.pin, value)
+
+    def __init__(self, pin, direction, pull=None, value=None):
+        """Initialize the GPIO.
+
+        Pin and direction are required arguments. Pull and value will be set
+        only if given.
+        """
+        self.pin = pin
+        super().__init__(pin, direction, pull, value)

--- a/notecard/platform.py
+++ b/notecard/platform.py
@@ -1,0 +1,21 @@
+"""Module for detecting the platform note-python is running on."""
+
+import sys
+
+platform = None
+
+if sys.implementation.name == 'circuitpython':
+    import digitalio
+    platform = 'circuitpython'
+elif sys.implementation.name == 'micropython':
+    import machine
+    platform = 'micropython'
+elif sys.implementation.name == 'cpython':
+    try:
+        with open('/etc/os-release', 'r') as f:
+            use_raspbian = 'ID=raspbian' in f.read()
+    except IOError:
+        pass
+
+    if use_raspbian:
+        platform = 'raspbian'

--- a/notecard/timeout.py
+++ b/notecard/timeout.py
@@ -1,0 +1,40 @@
+"""Module for managing timeouts in note-python."""
+
+import sys
+import time
+
+from .platform import platform
+
+use_rtc = platform != 'micropython' and platform != 'circuitpython'
+
+if not use_rtc:
+    if platform == 'circuitpython':
+        import supervisor
+        from supervisor import ticks_ms
+
+        _TICKS_PERIOD = 1 << 29
+        _TICKS_MAX = _TICKS_PERIOD - 1
+        _TICKS_HALFPERIOD = _TICKS_PERIOD // 2
+
+        def ticks_diff(ticks1, ticks2):
+            """Compute the signed difference between two ticks values."""
+            diff = (ticks1 - ticks2) & _TICKS_MAX  # noqa: F821
+            diff = ((diff + _TICKS_HALFPERIOD)  # noqa: F821
+                    & _TICKS_MAX) - _TICKS_HALFPERIOD  # noqa: F821
+            return diff
+
+    if platform == 'micropython':
+        from utime import ticks_diff, ticks_ms  # noqa: F811
+
+
+def has_timed_out(start, timeout_secs):
+    """Determine whether a timeout interval has passed during communication."""
+    if not use_rtc:
+        return ticks_diff(ticks_ms(), start) > timeout_secs * 1000
+    else:
+        return time.time() > start + timeout_secs
+
+
+def start_timeout():
+    """Start the timeout interval for I2C communication."""
+    return ticks_ms() if not use_rtc else time.time()

--- a/notecard/transaction_manager.py
+++ b/notecard/transaction_manager.py
@@ -1,0 +1,60 @@
+"""TransactionManager-related code for note-python."""
+
+import sys
+import time
+
+from .timeout import start_timeout, has_timed_out
+from .gpio import GPIO
+
+
+class TransactionManager:
+    """Class for managing the start and end of Notecard transactions.
+
+    Some Notecards need to be signaled via GPIO when a transaction is about to
+    start. When the Notecard sees a particular GPIO, called RTX (ready to
+    transact), go high, it responds with a high pulse on another GPIO, CTX
+    (clear to transact). At this point, the transaction can proceed. This class
+    implements this protocol in its start method.
+    """
+
+    def __init__(self, rtx_pin, ctx_pin):
+        """Initialize the TransactionManager.
+
+        Even though RTX is an output, we set it as an input here to conserve
+        power until we need to use it.
+        """
+        self.rtx_pin = GPIO.setup(rtx_pin, GPIO.IN)
+        self.ctx_pin = GPIO.setup(ctx_pin, GPIO.IN)
+
+    def start(self, timeout_secs):
+        """Prepare the Notecard for a transaction."""
+        start = start_timeout()
+
+        self.rtx_pin.direction(GPIO.OUT)
+        self.rtx_pin.value(1)
+        # If the Notecard supports RTX/CTX, it'll pull CTX low. If the Notecard
+        # doesn't support RTX/CTX, this pull up will make sure we get the clear
+        # to transact immediately.
+        self.ctx_pin.pull(GPIO.PULL_UP)
+
+        # Wait for the Notecard to signal clear to transact (i.e. drive the CTX
+        # pin HIGH). Time out after timeout_secs seconds.
+        while True:
+            if self.ctx_pin.value():
+                break
+
+            if (has_timed_out(start, timeout_secs)):
+                # Abandon request on timeout.
+                self.stop()
+                raise Exception(
+                    "Timed out waiting for Notecard to give clear to transact."
+                )
+
+            time.sleep(.001)
+
+        self.ctx_pin.pull(GPIO.PULL_NONE)
+
+    def stop(self):
+        """Make RTX an input to conserve power and remove the pull up on CTX."""
+        self.rtx_pin.direction(GPIO.IN)
+        self.ctx_pin.pull(GPIO.PULL_NONE)


### PR DESCRIPTION
CTX/RTX requires interacting with 2 GPIO pins, so I added a gpio.py file to
handle abstracting GPIO for 3 platforms: CircuitPython, MicroPython, and
Raspberry Pi (Raspbian). The core of the CTX/RTX code lives in
transaction_manager.py. This file uses the code in gpio.py to implement the
CTX/RTX protocol. This gets used in notecard.py when any Notecard transaction
occurs, so long as the transaction pins have been set. If they haven't been set,
everything behaves as before.

I tested this functionality on all 3 supported platforms by hooking up a
push button to the CTX pin and an LED to the RTX pin. I issued a hub.set request
and the LED lit up. The transaction only went through after I pushed the button,
simulating a CTX pulse from the Notecard.

Additionally, I refactored some other code:

- platform.py is used to determine the platform we're on. We need to know this
info throughout the code, so it makes sense to move it into a single file.
- timeout.py is used for timeouts, which are also used throughout the code.