### PR TITLE
Upgrade pytest dependency to 7.0.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyserial==3.4
 python-periphery==2.3.0
 PyYAML==5.4
 flake8==3.8.3
-pytest==5.4.3
+pytest==7.0.1
 pytest-cov==2.8.1
 filelock==3.0.12
 pydocstyle==5.0.2


### PR DESCRIPTION
I get an error like this when I try to run the tests:

TypeError: required field "lineno" missing from alias

This was apparently fixed in a later version than we specify in
requirements.txt: https://github.com/pytest-dev/pytest/discussions/9195

This commit moves us from 5.4.3, which is 3 years old, to 7.0.1. We can't move
to the latest version, 7.4.0, because it only supports Python >= 3.7, and we're
stuck on 3.6, for now.