### PR TITLE
Revert "change validators import for MicroPython"

### DIFF
--- a/notecard/card.py
+++ b/notecard/card.py
@@ -10,11 +10,7 @@
 # This module is optional and not required for use with the Notecard.
 
 import notecard
-import sys
-if sys.implementation.name == 'micropython':
-    from validators import validate_card_object
-else:
-    from .validators import validate_card_object
+from .validators import validate_card_object
 
 
 @validate_card_object

--- a/notecard/env.py
+++ b/notecard/env.py
@@ -10,11 +10,7 @@
 # This module is optional and not required for use with the Notecard.
 
 import notecard
-import sys
-if sys.implementation.name == 'micropython':
-    from validators import validate_card_object
-else:
-    from .validators import validate_card_object
+from .validators import validate_card_object
 
 
 @validate_card_object

--- a/notecard/file.py
+++ b/notecard/file.py
@@ -10,11 +10,7 @@
 # This module is optional and not required for use with the Notecard.
 
 import notecard
-import sys
-if sys.implementation.name == 'micropython':
-    from validators import validate_card_object
-else:
-    from .validators import validate_card_object
+from .validators import validate_card_object
 
 
 @validate_card_object

--- a/notecard/hub.py
+++ b/notecard/hub.py
@@ -10,11 +10,7 @@
 # This module is optional and not required for use with the Notecard.
 
 import notecard
-import sys
-if sys.implementation.name == 'micropython':
-    from validators import validate_card_object
-else:
-    from .validators import validate_card_object
+from .validators import validate_card_object
 
 
 @validate_card_object

--- a/notecard/note.py
+++ b/notecard/note.py
@@ -10,11 +10,7 @@
 # This module is optional and not required for use with the Notecard.
 
 import notecard
-import sys
-if sys.implementation.name == 'micropython':
-    from validators import validate_card_object
-else:
-    from .validators import validate_card_object
+from .validators import validate_card_object
 
 
 @validate_card_object


### PR DESCRIPTION
This reverts commit 3d832cfb391b270f32080378ffcda14c4eec5329.

Upon testing, this change prevents the validators import functioning correctly on current Micropython versions.