### PR TITLE
Refactor for readability and reuse and other improvements.

### DIFF
--- a/test/test_notecard.py
+++ b/test/test_notecard.py
@@ -462,7 +462,7 @@ class TestUserAgent:
         nCard = MockNotecard()
         orgReq = {"req": "hub.set"}
         nCard.SetAppUserAgent(info)
-        req = nCard._preprocessReq(orgReq)
+        req = nCard._preprocess_req(orgReq)
         return req
 
     def test_amends_hub_set_request(self):


### PR DESCRIPTION
- Add comments explaining some of the delays used in serial and I2C comms.
- Refactor internal functions (those with a leading _) to be snake_case. Not changing external functions to preserve backwards compatibility.
- Change some variable names in _send_payload to improve readability. Also, fix a bug in this function where we weren't sleeping properly between segments (looks to be an indentation error). Finally, sleep 20ms between writing I2C chunks in this function, which is what we document on blues.dev as the "right way" to do it.
- Factor out reading from the Notecard over I2C into a new internal function, _receive. This is used both by Transaction and Reset. There was also a bug in Transaction that's fixed in this new function. There was a `continue` statement that was preempting both our timeout check and delaying between chunks.