### PR TITLE
feat: Refactor serial and I2C code.

### DIFF
--- a/notecard/transaction_manager.py
+++ b/notecard/transaction_manager.py
@@ -58,3 +58,19 @@ class TransactionManager:
         """Make RTX an input to conserve power and remove the pull up on CTX."""
         self.rtx_pin.direction(GPIO.IN)
         self.ctx_pin.pull(GPIO.PULL_NONE)
+
+
+class NoOpTransactionManager:
+    """Class for transaction start/stop when no transaction pins are set.
+
+    If the transaction pins aren't set, the start and stop operations should be
+    no-ops.
+    """
+
+    def start(self, timeout_secs):
+        """No-op start function."""
+        pass
+
+    def stop(self):
+        """No-op stop function."""
+        pass

--- a/test/test_notecard.py
+++ b/test/test_notecard.py
@@ -3,6 +3,7 @@ import sys
 import pytest
 from unittest.mock import Mock, MagicMock, patch
 import periphery
+import json
 
 sys.path.insert(0,
                 os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -462,7 +463,7 @@ class TestUserAgent:
         nCard = MockNotecard()
         orgReq = {"req": "hub.set"}
         nCard.SetAppUserAgent(info)
-        req = nCard._preprocess_req(orgReq)
+        req = json.loads(nCard._prepare_request(orgReq))
         return req
 
     def test_amends_hub_set_request(self):


### PR DESCRIPTION
- Get rid of conditionals on transaction manager existence and if serial locking should be used by adding no-op implementations of each.
- Handle serial and I2C locking with decorators, serial_lock and i2c_lock, respectively.
- Add timeout functionality to I2C locking. Prior to this commit, it would spin forever if the lock couldn't be acquired.
- For both serial and I2C, combine common code from Transaction and Command into an internal function, _transact. Locking happens over this function.
- Migrate all freestanding serial functions to methods of OpenSerial.
- Create a _read_byte abstraction for the three platforms we support (CPython, MicroPython, CircuitPython).
- Merge the functionality of _preprocess_req into _prepare_request. These are always used together, so it doesn't really make sense to have them as separate functions. Additionally, have _prepare_request do everything needed to transform the request data for transmission. Namely, encode the request string as UTF-8 bytes. Finally, make _prepare_request a method of Notecard. There's no reason for it to be a free function.
- Rename I2C's _send_payload to _transmit.