### PR TITLE
Handle "not supported" errors in the core Transaction function.

### DIFF
--- a/notecard/notecard.py
+++ b/notecard/notecard.py
@@ -344,7 +344,7 @@ class Notecard:
                         continue
 
                     if 'err' in rsp_json:
-                        if '{io}' in rsp_json['err']:
+                        if '{io}' in rsp_json['err'] and '{not-supported}' not in rsp_json['err']:
                             if self._debug:
                                 print('Response has error field indicating ' + \
                                       f'I/O error: {rsp_json}')

--- a/test/test_notecard.py
+++ b/test/test_notecard.py
@@ -294,6 +294,16 @@ class TestNotecard:
             assert card._transact.call_count == \
                    notecard.CARD_TRANSACTION_RETRIES
 
+    def test_transaction_does_not_retry_on_not_supported_error_in_response(
+            self, arrange_transaction_test):
+        card = arrange_transaction_test()
+        req = {"req": "hub.status"}
+
+        with patch('notecard.notecard.json.loads',
+                   return_value={'err': 'some error {io} {not-supported}'}):
+            card.Transaction(req)
+            assert card._transact.call_count == 1
+
     def test_transaction_does_not_retry_on_bad_bin_error_in_response(
             self, arrange_transaction_test):
         card = arrange_transaction_test()


### PR DESCRIPTION
If the Notecard's response contains an error with "{not-supported}", do not retry the transaction.