### PR TITLE
Add Notestation dev environment

### DIFF
--- a/.devcontainer/notestation/.env.example
+++ b/.devcontainer/notestation/.env.example
@@ -1,0 +1,3 @@
+# This value must be replaced with a valid Tailscale Authorization Key
+# to gain access to the Notestation array.
+TS_AUTHKEY=tskey-auth-xxxxxxxxxxxxxxxxx-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/.devcontainer/notestation/Dockerfile
+++ b/.devcontainer/notestation/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.10-slim
+
+ARG USER="blues"
+
+RUN apt-get update && apt-get install -y \
+    git \
+    && rm -rf /var/lib/apt/lists/* && \
+    useradd -ms /bin/bash ${USER}
+
+USER ${USER}
+
+WORKDIR /workspace
+
+RUN pip install pyserial requests
+
+# Install note-python in editable mode
+CMD ["pip", "install", "-e", "."]

--- a/.devcontainer/notestation/devcontainer.json
+++ b/.devcontainer/notestation/devcontainer.json
@@ -1,0 +1,54 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/docker-existing-dockerfile
+{
+    "name": "Notestation Python Development Environment",
+
+    // Use 'dockerComposeFile' to specify a docker-compose.yml file.
+    "dockerComposeFile": "docker-compose.yaml",
+
+    // Set the service to use for the container.
+    "service": "devcontainer",
+
+    // Use 'workspaceFolder' to specify the folder to open in the container.
+    "workspaceFolder": "/workspace",
+
+    // Set environment variables inside the container(s)
+    "containerEnv": {},
+
+    // Set *default* container specific settings.json values on container create.
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "shardulm94.trailing-spaces"
+            ],
+            "settings": {}
+        }
+    },
+
+    // Set environment variables for the container(s)
+    "remoteEnv": {
+        "BLUES": "${localEnv:BLUES}"
+    },
+
+    // Inject unique hostname into tailnet
+    "initializeCommand": "printf 'TS_HOSTNAME=vscode-client-%s\\n' \"${localEnv:USER}\" | tr '[:upper:]' '[:lower:]' | sed 's/^ts_hostname/TS_HOSTNAME/' > .devcontainer/notestation/ts_config.env",
+
+    // Run commands after the container is created -> setup the execution environment
+    "postCreateCommand": "pip install -e .",
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+    // "runArgs": [
+    //     "--device=/dev/bus/usb/"
+    // ],
+
+    // Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+    // "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+    // Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "blues"
+}

--- a/.devcontainer/notestation/devcontainer.json
+++ b/.devcontainer/notestation/devcontainer.json
@@ -21,7 +21,7 @@
             "extensions": [
                 "ms-python.python",
                 "ms-python.vscode-pylance",
-                "shardulm94.trailing-spaces"
+                "shardulm94.trailing-spaces",\n                "${containerWorkspaceFolder}/.vscode/extensions/notestation-2.0.1.vsix"
             ],
             "settings": {}
         }

--- a/.devcontainer/notestation/docker-compose.yaml
+++ b/.devcontainer/notestation/docker-compose.yaml
@@ -1,0 +1,40 @@
+# .devcontainer/docker-compose.yaml
+
+name: note-arduino
+services:
+  devcontainer:
+    # image: ghcr.io/blues/note_arduino_ci:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: note-arduino_devcontainer
+    command: sleep infinity
+    depends_on:
+      - tailscale
+    network_mode: service:tailscale  # Share network with tailscale service
+    stdin_open: true
+    tty: true
+    volumes:
+      - ../..:/workspace:cached
+
+  tailscale:
+    image: tailscale/tailscale:v1.90.6
+    cap_add:
+      - NET_ADMIN  # Network admin privileges
+      - SYS_MODULE  # Required for TUN device
+    container_name: note-arduino_tailnet-connection
+    env_file:
+      - .env
+      - ts_config.env  # Load Tailscale config from generated file
+    environment:
+      - TS_ACCEPT_DNS=true  # Allows tailnet DNS resolution
+      # - TS_AUTHKEY=  # DO NOT POPULATE - Loaded automatically from `.env` file
+      # - TS_HOSTNAME= # DO NOT POPULATE - Loaded automatically from `ts_config.env`
+      - TS_STATE_DIR=/var/lib/tailscale  # Persist state
+      - TS_USERSPACE=false  # Use kernel networking (faster; requires TUN device)
+    restart: unless-stopped
+    volumes:
+      - tailscale-var-lib:/var/lib/tailscale  # Named volume for state
+
+volumes:
+  tailscale-var-lib:  # Defines the named volume

--- a/.devcontainer/notestation/docker-compose.yaml
+++ b/.devcontainer/notestation/docker-compose.yaml
@@ -1,13 +1,13 @@
+version: "3.8"
 # .devcontainer/docker-compose.yaml
 
-name: note-arduino
 services:
   devcontainer:
-    # image: ghcr.io/blues/note_arduino_ci:latest
+    # image: ghcr.io/blues/note_python_ci:latest
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: note-arduino_devcontainer
+    container_name: note-python_devcontainer
     command: sleep infinity
     depends_on:
       - tailscale
@@ -22,7 +22,7 @@ services:
     cap_add:
       - NET_ADMIN  # Network admin privileges
       - SYS_MODULE  # Required for TUN device
-    container_name: note-arduino_tailnet-connection
+    container_name: note-python_tailnet-connection
     env_file:
       - .env
       - ts_config.env  # Load Tailscale config from generated file

--- a/examples/validate_notestation_micropython.py
+++ b/examples/validate_notestation_micropython.py
@@ -1,0 +1,15 @@
+"""Simple MicroPython script to validate Notestation dev environment.
+
+Assumes Notestation provides a UART connection at UART2 or adjust accordingly.
+"""
+
+from machine import UART
+import notecard
+
+port = UART(2, 9600)
+port.init(9600, bits=8, parity=None, stop=1)
+
+card = notecard.OpenSerial(port)
+
+rsp = card.Transaction({"req": "card.version"})
+print(rsp)


### PR DESCRIPTION
Adds a devcontainer setup for Notestation to note-python, adapted from note-arduino. This allows testing the Python library with real Notecard hardware via Tailscale.