### PR TITLE
Fix web.get test to remove unsupported async_ parameter

### DIFF
--- a/test/fluent_api/test_web.py
+++ b/test/fluent_api/test_web.py
@@ -30,16 +30,13 @@ from notecard import web
                 'body': {'key': 'value'},
                 'content': 'application/json',
                 'seconds': 60,
-                'async_': False,
                 'binary': True,
                 'offset': 0,
                 'max': 1024,
                 'file': 'responses.dbx',
                 'note': 'get_response_1'
             },
-            {
-                'async_': 'async'
-            }
+            None
         ),
         (
             web.post,


### PR DESCRIPTION
The async_ parameter was removed from web.get but the test was not updated to reflect this. Remove async_ and its rename_key_map entry from the web.get parametrize fixture.