### PR TITLE
fix: protect backtick spans before stripping markdown italic in docstring generator

### DIFF
--- a/scripts/generate_apis.py
+++ b/scripts/generate_apis.py
@@ -126,12 +126,22 @@ class NotecardAPIGenerator:
         import re
         text = re.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', text)
 
-        # Remove markdown emphasis formatting (* and _)
-        # Handle both single and double emphasis markers
+        # Remove markdown emphasis formatting (* and _), but protect backtick-quoted
+        # spans first so identifiers like SERIAL_RX_BUFFER_SIZE are not corrupted.
+        placeholders = {}
+        def save_backtick(m):
+            key = f"\x00BACKTICK{len(placeholders)}\x00"
+            placeholders[key] = m.group(0)
+            return key
+        text = re.sub(r'`[^`]*`', save_backtick, text)
+
         text = re.sub(r'\*\*([^*]+)\*\*', r'\1', text)  # **bold** -> bold
         text = re.sub(r'\*([^*]+)\*', r'\1', text)      # *italic* -> italic
         text = re.sub(r'__([^_]+)__', r'\1', text)      # __bold__ -> bold
         text = re.sub(r'_([^_]+)_', r'\1', text)        # _italic_ -> italic
+
+        for key, val in placeholders.items():
+            text = text.replace(key, val)
 
         # Collapse multiple spaces into single spaces
         text = re.sub(r'\s+', ' ', text)


### PR DESCRIPTION
## Summary

- The `clean_docstring_text` method in `scripts/generate_apis.py` was applying a `_([^_]+)_` regex to strip markdown italic formatting, but this also matched underscores *inside* backtick-quoted identifiers
- `SERIAL_RX_BUFFER_SIZE` → `SERIALRXBUFFER_SIZE` because `_RX_` was treated as italic markdown and stripped
- Fixed by temporarily saving all backtick spans before the emphasis-stripping pass, then restoring them afterward

This is the root cause behind #174 — the upstream schema has always had the correct `SERIAL_RX_BUFFER_SIZE`, but the generator was corrupting it on every automated build run.

## Test plan

- [ ] Verify `SERIAL_RX_BUFFER_SIZE` is preserved in `notecard/card.py` after running `pipenv run python scripts/generate_apis.py --output-dir notecard`
- [ ] Confirm italic markdown like `_italic_` outside of backticks is still stripped correctly
- [ ] Close #174 after this merges and an automated schema update runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)